### PR TITLE
Buy and Sell APIs Successfully working.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -47,7 +47,7 @@ dfx identity new minter
   dfx identity use minter
   export MINTER_ACCOUNT_ID=$(dfx ledger account-id)
 
-  dfx identity use default
+  dfx identity use buyer
   export DEFAULT_ACCOUNT_ID=$(dfx ledger account-id)
 
 dfx identity use controller 

--- a/deployicpledger.sh
+++ b/deployicpledger.sh
@@ -1,7 +1,7 @@
 dfx identity use minter
 export MINTER_ACCOUNT_ID=$(dfx ledger account-id)
 
-dfx identity use default
+dfx identity use buyer
 export DEFAULT_ACCOUNT_ID=$(dfx ledger account-id)
 
 dfx identity use controller 

--- a/src/icplaunchpad_backend/icplaunchpad_backend.did
+++ b/src/icplaunchpad_backend/icplaunchpad_backend.did
@@ -1,4 +1,9 @@
 type Account = record { owner : principal; subaccount : opt blob };
+type BuyTransferParams = record {
+  icrc1_ledger_canister_id : principal;
+  tokens : nat64;
+  buyer_principal : principal;
+};
 type CanisterIndexInfo = record {
   token_symbol : text;
   canister_id : text;
@@ -41,6 +46,11 @@ type SaleDetailsWithID = record {
   sale_details : SaleDetails;
   ledger_canister_id : text;
 };
+type SellTransferParams = record {
+  to_principal : principal;
+  token_ledger_canister_id : principal;
+  tokens : nat64;
+};
 type TokenCreationResult = record {
   index_canister_id : principal;
   ledger_canister_id : principal;
@@ -59,7 +69,7 @@ type UserInputParams = record {
   token_name : text;
 };
 service : () -> {
-  buy_tokens : (nat64, principal, principal) -> (Result);
+  buy_tokens : (BuyTransferParams) -> (Result);
   create_account : (UserAccount) -> (Result_1);
   create_sale : (principal, SaleDetails) -> (Result_1);
   create_token : (UserInputParams) -> (Result_2);
@@ -79,7 +89,7 @@ service : () -> {
   get_user_tokens_info : () -> (vec CanisterIndexInfo) query;
   is_account_created : () -> (text) query;
   search_by_token_name_or_symbol : (text) -> (opt CanisterIndexInfo) query;
-  sell_tokens : (nat64, principal, principal, principal) -> (Result);
+  sell_tokens : (SellTransferParams) -> (Result);
   update_sale_params : (principal, SaleDetailsUpdate) -> (Result_1);
   update_user_account : (principal, UserAccount) -> (Result_1);
   upload_cover_image : (text, CoverImageData) -> (Result_5);

--- a/src/icplaunchpad_backend/src/lib.rs
+++ b/src/icplaunchpad_backend/src/lib.rs
@@ -13,9 +13,9 @@ mod transaction;
 mod types;
 mod api_update;
 use state_handler::*;
-mod api_query;
+mod api_query;   
 use types::*;
-
+use crate::transaction::*;
 use candid::Nat;
 
 


### PR DESCRIPTION
Tweaked the logic in Buy and Sell APIs:

1. Buy logic working: The buyer first approves the backend canister, with the amount he wishes to buy the tokens in ICP, after the approval is success, buy_tokens can be used for the rest process. On entering the details of token ledger canister id he wishes to buy, amount, ICP is transferred to that particular token canister's owner principal.
2: Sell logic working: The seller first as of now, approves the entire total supply as allowance to the backend canister, this is assumed to be done at the start, when the sale is started. Now, that backend canister already has approval, sell_tokens can be used for the rest process. On entering the details of token ledger canister id, and amount that buyer initially wanted, tokens are transferred to the entered buy principal.