### PR TITLE
Import_token and get_user_ledger_ids APIs added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,6 @@ checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -100,29 +88,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
-name = "canbench-rs"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497d900e11ab1891dd9743dd45dbeaada540ce323aa1adc7fc0ce1da2c6e86ff"
-dependencies = [
- "canbench-rs-macros",
- "candid",
- "ic-cdk 0.12.2",
- "serde",
-]
-
-[[package]]
-name = "canbench-rs-macros"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5509bcfe6eeb86f057d46fbf20a2ba6b6bf9a1099b053a8f491cd7a909dfa6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "candid"
 version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "canfund"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c42a35e7957a90b5e2c7c31960f12961ad17a703ad11de3dc6946eec64890f"
+checksum = "087c0440ceb58ee2354e61caf0a2388698f9f566cad192c7169b9c03c461ad9f"
 dependencies = [
  "async-trait",
  "candid",
@@ -487,7 +452,7 @@ name = "hyperx"
 version = "1.4.2"
 source = "git+https://github.com/ldclabs/hyperx#4b9bd373b8c4d29a32e59912bf598ba69273c032"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "http 1.2.0",
  "httpdate",
@@ -499,55 +464,28 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e908da565d9e304e83732500069ebb959e3d2cad80f894889ea37207112c7a0"
-dependencies = [
- "candid",
- "ic-cdk-macros 0.8.4",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038ff230bf0fc8630943e3c52e989d248a7c89834ccb65da408fabc5817a475b"
 dependencies = [
  "candid",
  "ic-cdk-macros 0.15.0",
- "ic0 0.23.0",
+ "ic0",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "ic-cdk"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8ecacd682fa05a985253592963306cb9799622d7b1cce4b1edb89c6ec85be1"
+checksum = "b2abdf9341da9f9f6b451a40609cb69645a05a8e9eb7784c16209f16f2c0f76f"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.16.0",
- "ic0 0.23.0",
+ "ic-cdk-macros 0.17.0",
+ "ic0",
  "serde",
  "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -560,21 +498,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.2.2",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4d857135deef20cc7ea8f3869a30cd9cfeb1392b3a81043790b2cd82adc3e0"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.2.2",
+ "serde_tokenstream",
  "syn 2.0.90",
 ]
 
@@ -588,7 +512,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.2.2",
+ "serde_tokenstream",
  "syn 2.0.90",
 ]
 
@@ -600,7 +524,7 @@ checksum = "61fdca8e1d9ffb65ae68019b342c182009de9dc206fd849db0b0e90ee19f6fa4"
 dependencies = [
  "futures",
  "ic-cdk 0.15.1",
- "ic0 0.23.0",
+ "ic0",
  "serde",
  "serde_bytes",
  "slotmap",
@@ -669,12 +593,6 @@ dependencies = [
 
 [[package]]
 name = "ic0"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
-
-[[package]]
-name = "ic0"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
@@ -683,7 +601,7 @@ checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
 name = "ic_asset_handler"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bytes",
  "candid",
  "ciborium",
@@ -691,7 +609,7 @@ dependencies = [
  "hex",
  "hmac",
  "hyperx",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.0",
  "ic-cdk-timers",
  "ic-http-certification",
  "ic-stable-structures",
@@ -722,12 +640,11 @@ dependencies = [
 name = "icplaunchpad_backend"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.1",
- "canbench-rs",
+ "base64",
  "candid",
  "canfund",
  "futures",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.0",
  "ic-cdk-macros 0.17.0",
  "ic-cdk-timers",
  "ic-ledger-types",
@@ -1143,17 +1060,6 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_tokenstream"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
-dependencies = [
- "proc-macro2",
- "serde",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/canbench.yml
+++ b/canbench.yml
@@ -1,5 +1,0 @@
-build_cmd:
-  cargo build --release --target wasm32-unknown-unknown --features canbench-rs
-
-wasm_path:
-  ./target/wasm32-unknown-unknown/release/icplaunchpad_backend.wasm

--- a/src/ic_asset_handler/Cargo.toml
+++ b/src/ic_asset_handler/Cargo.toml
@@ -17,7 +17,7 @@ candid = "0.10"
 ciborium = "0.2"
 # sha2 = "0.10"
 sha3 = "0.10"
-ic-cdk = "0.16.0"
+ic-cdk = "0.17.0"
 ic-cdk-timers = "0.9.0"
 ic-stable-structures = "0.6"
 ic-http-certification = { version = "2.5", features = ["serde"] }
@@ -26,8 +26,8 @@ crc32fast = "1.4"
 hmac = "0.12"
 serde = "1"
 serde_bytes = "0.11"
-serde_json = { version = "1", features = ["preserve_order"] }
-base64 = "0.21"
+serde_json = { version = "1.0", features = ["preserve_order"] }
+base64 = "0.22.1"
 once_cell = "1.19"
-hyperx = { git = "https://github.com/ldclabs/hyperx", version = "1.4" }
+hyperx = { git = "https://github.com/ldclabs/hyperx", version = "1.4.2" }
 lazy_static = "1.4"

--- a/src/icplaunchpad_backend/Cargo.toml
+++ b/src/icplaunchpad_backend/Cargo.toml
@@ -10,21 +10,22 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde = { version = "1.0.160", features = ["derive"] }  
-base64 = "0.13.0"
+base64 = "0.22.1"
 candid = "0.10"
-ic-cdk = "0.16.0"
+ic-cdk = "0.17.0"
 ic-stable-structures = "0.6.5"
-serde_bytes = "0.11.14"
+serde_bytes = "0.11"
 serde_json = "1.0"
 lazy_static = "1.4"
 icrc-ledger-types= "0.1.5"
-ic-ledger-types = "0.12"
+ic-ledger-types = "0.12.0"
 url = "2.5.2"
-canfund = "0.3.0"
+canfund = "0.4.0"
 futures = "0.3.31"
 ic-cdk-macros = "0.17.0"
 ic-cdk-timers = "0.9.0"
-canbench-rs = { version = "0.1.8", optional = false }
+
+
 
 
 

--- a/src/icplaunchpad_backend/icplaunchpad_backend.did
+++ b/src/icplaunchpad_backend/icplaunchpad_backend.did
@@ -119,10 +119,12 @@ service : () -> {
   get_upcoming_sales : () -> (vec record { SaleDetailsWithID; nat }) query;
   get_user_account : (principal) -> (opt UserAccount) query;
   get_user_by_username : (text) -> (opt UserAccount) query;
+  get_user_ledger_ids : (principal) -> (vec principal) query;
   get_user_sale_params : () -> (Result_7) query;
   get_user_tokens_info : () -> (vec CanisterIndexInfo) query;
   icrc28_trusted_origins : () -> (Icrc28TrustedOriginsResponse);
   icrc_get_balance : (principal) -> (Result_5);
+  import_token : (principal) -> ();
   insert_funds_raised : (principal, nat64) -> (Result_1);
   is_account_created : () -> (text) query;
   obtain_cycles_for_canister : (nat, principal) -> (Result_5);

--- a/src/icplaunchpad_backend/src/api_update.rs
+++ b/src/icplaunchpad_backend/src/api_update.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use candid::{encode_one, Nat, Principal};
-use ic_cdk::api::{
+use ic_cdk::{api::{
     call::{call_with_payment128, CallResult, RejectionCode},
     management_canister::main::{CanisterInstallMode, WasmModule},
-};
+}, caller, update};
 use ic_ledger_types::Subaccount;
 
 use crate::{
-    create_canister, deposit_cycles, index_install_code, install_code, mutate_state, params::{self}, read_state, Account, CanisterIdRecord, CanisterIdWrapper, CoverImageData, CoverImageIdWrapper, CreateCanisterArgument, CreateFileInput, ImageIdWrapper, IndexArg, IndexCanisterIdWrapper, IndexInitArgs, IndexInstallCodeArgument, InitArgs, InstallCodeArgument, LedgerArg, ProfileImageData, ReturnResult, SaleDetails, SaleDetailsUpdate, SaleDetailsWrapper, SaleInputParams, TokenCreationResult, TokenImageData, U64Wrapper, UserAccount, UserAccountWrapper, UserInputParams, STATE
+    create_canister, deposit_cycles, index_install_code, install_code, mutate_state, params::{self}, read_state, Account, CanisterIdRecord, CanisterIdWrapper, CoverImageData, CoverImageIdWrapper, CreateCanisterArgument, CreateFileInput, ImageIdWrapper, ImportedCanisterIdWrapper, IndexArg, IndexCanisterIdWrapper, IndexInitArgs, IndexInstallCodeArgument, InitArgs, InstallCodeArgument, LedgerArg, ProfileImageData, ReturnResult, SaleDetails, SaleDetailsUpdate, SaleDetailsWrapper, SaleInputParams, TokenCreationResult, TokenImageData, U64Wrapper, UserAccount, UserAccountWrapper, UserInputParams, STATE
 };
 
 use canfund::api::cmc::IcCyclesMintingCanister;
@@ -323,6 +323,24 @@ pub async fn create_token(user_params: UserInputParams) -> Result<TokenCreationR
             ));
         }
     }
+}
+
+#[update]
+pub fn import_token(ledger_canister_id: Principal) {
+    let user_principal = caller();  // Get the Principal of the caller (user)
+    
+    // Create an ImportedCanisterIdWrapper with the user principal and ledger canister ID
+    let wrapper = ImportedCanisterIdWrapper {
+        caller: user_principal,
+        ledger_canister_id,
+    };
+
+    // Store the user's principal and the corresponding ledger canister ID wrapper in stable memory
+    mutate_state(|state| {
+        state.imported_canister_ids.insert(user_principal.to_string(), wrapper);
+    });
+
+    ic_cdk::println!("Token ledger canister ID imported successfully by {:?}", user_principal);
 }
 
 #[ic_cdk::update]

--- a/src/icplaunchpad_backend/src/types.rs
+++ b/src/icplaunchpad_backend/src/types.rs
@@ -5,6 +5,20 @@ use serde_bytes::ByteBuf;
 
 use crate::state_handler::*;
 
+
+pub struct State {
+    pub canister_ids: CanisterIdsMap,
+    pub index_canister_ids: IndexCanisterIdsMap,
+    pub image_ids: ImageIdsMap,
+    pub sale_details: SaleDetailsMap,
+    pub user_accounts: UserAccountsMap,
+    pub cover_image_ids: CoverImageIdsMap,
+    pub funds_raised: FundsRaisedMap,
+    pub contributions: ContributionsMap,
+    pub imported_canister_ids: ImportedCanisterIdsMap
+}
+
+
 #[derive(Serialize, Deserialize, Clone, CandidType, Debug)]
 pub struct UserAccount {
     pub name: String,
@@ -299,16 +313,7 @@ pub struct SaleDetailsUpdate {
     pub project_video: Option<String>, // Optional field to update the project video
 }
 
-pub struct State {
-    pub canister_ids: CanisterIdsMap,
-    pub index_canister_ids: IndexCanisterIdsMap,
-    pub image_ids: ImageIdsMap,
-    pub sale_details: SaleDetailsMap,
-    pub user_accounts: UserAccountsMap,
-    pub cover_image_ids: CoverImageIdsMap,
-    pub funds_raised: FundsRaisedMap,
-    pub contributions: ContributionsMap,
-}
+
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct CanisterIdWrapper {
@@ -320,6 +325,13 @@ pub struct CanisterIdWrapper {
     pub owner: Principal,
     pub total_supply: Nat,
 }
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct ImportedCanisterIdWrapper {
+    pub caller: Principal,
+    pub ledger_canister_id: Principal,
+}
+
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct IndexCanisterIdWrapper {


### PR DESCRIPTION
This pull request introduces the following updates and improvements:

- **Dependency Updates**: Adjustments made due to changes in the `canfund` package.  
- **import_token Function**: Added functionality to store the imported ledger IDs associated with a user.  
- **get_user_ledger_ids Function**: Implemented to return all canister IDs created by the user through the create_token and import_token functions.
