### PR TITLE
Token Image Ids new map and logic changed accordingly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ dependencies = [
  "ic-stable-structures",
  "icrc-ledger-types",
  "lazy_static",
+ "num-traits",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,6 +47,7 @@ dfx deploy token_deployer --argument '(
   }
 )'
 
+
 # Deploy the index canister with specified arguments
 dfx deploy index_canister --argument '(opt variant { Init = record { ledger_id = principal "aaaaa-aa"; retrieve_blocks_from_ledger_interval_seconds = opt 10 } })'
 
@@ -62,8 +63,9 @@ if [ -z "$MINTER_ACCOUNT_ID" ]; then
 fi
 
 # Switch back to the default identity and set DEFAULT_ACCOUNT_ID only if not already set
-dfx identity use controller
-DEFAULT_ACCOUNT_ID=$(dfx ledger account-id)
+dfx identity use default
+
+export DEFAULT_ACCOUNT_ID=$(dfx ledger account-id)
 
 
 # Switch back to the controller identity

--- a/src/icplaunchpad_backend/Cargo.toml
+++ b/src/icplaunchpad_backend/Cargo.toml
@@ -24,6 +24,7 @@ canfund = "0.4.0"
 futures = "0.3.31"
 ic-cdk-macros = "0.17.0"
 ic-cdk-timers = "0.9.0"
+num-traits = "0.2.19"
 
 
 

--- a/src/icplaunchpad_backend/icplaunchpad_backend.did
+++ b/src/icplaunchpad_backend/icplaunchpad_backend.did
@@ -31,7 +31,7 @@ type Result_11 = variant {
   Ok : vec record { SaleDetailsWithID; nat };
   Err : text;
 };
-type Result_12 = variant { Ok : vec record { nat32; principal }; Err : text };
+type Result_12 = variant { Ok : vec record { text; nat32 }; Err : text };
 type Result_13 = variant { Ok : vec CanisterIndexInfo; Err : text };
 type Result_14 = variant { Ok : UserAccount; Err : text };
 type Result_15 = variant { Ok : vec principal; Err : text };
@@ -119,10 +119,10 @@ service : () -> {
   create_account : (UserAccount) -> (Result_2);
   create_sale : (principal, SaleInputParams) -> (Result_3);
   create_token : (UserInputParams) -> (Result_4);
-  debug_index_canister_ids : () -> (vec record { text; text }) query;
   deposit_cycles_to_canister : (CanisterIdRecord, nat) -> (Result_5);
   fee_for_creation_token : () -> (float64) query;
   fetch_canister_balance : (principal) -> (Result_6);
+  fetch_canister_balance_new : (principal) -> (Result_6);
   get_active_sales : () -> (Result_7) query;
   get_all_sales : () -> (Result_8) query;
   get_contributions_for_sale : (principal) -> (

--- a/src/icplaunchpad_backend/src/state_handler.rs
+++ b/src/icplaunchpad_backend/src/state_handler.rs
@@ -9,29 +9,31 @@ use std::cell::RefCell;
 
 use crate::task_scheduler::process_sales;
 use crate::{
-    CanisterIdWrapper, CoverImageIdWrapper, ImageIdWrapper, ImportedCanisterIdWrapper, IndexCanisterIdWrapper, SaleDetailsWrapper, State, U64Wrapper, UserAccountWrapper
+    CanisterIdWrapper, CoverImageIdWrapper, ImportedCanisterIdWrapper, IndexCanisterIdWrapper, ProfileImageIdWrapper, SaleDetailsWrapper, State, TokenImageIdWrapper, U64Wrapper, UserAccountWrapper
 };
 
 pub type Memory = VirtualMemory<DefaultMemoryImpl>;
 pub type CanisterIdsMap = StableBTreeMap<String, CanisterIdWrapper, Memory>;
 pub type IndexCanisterIdsMap = StableBTreeMap<String, IndexCanisterIdWrapper, Memory>;
-pub type ImageIdsMap = StableBTreeMap<String, ImageIdWrapper, Memory>;
+pub type ProfileImageIdsMap = StableBTreeMap<String, ProfileImageIdWrapper, Memory>;
 pub type SaleDetailsMap = StableBTreeMap<Principal, SaleDetailsWrapper, Memory>;
 pub type UserAccountsMap = StableBTreeMap<Principal, UserAccountWrapper, Memory>;
 pub type CoverImageIdsMap = StableBTreeMap<String, CoverImageIdWrapper, Memory>;
 pub type FundsRaisedMap = StableBTreeMap<Principal, U64Wrapper, Memory>;
 pub type ContributionsMap = StableBTreeMap<(Principal, Principal), U64Wrapper, Memory>;
 pub type ImportedCanisterIdsMap = StableBTreeMap<String, ImportedCanisterIdWrapper, Memory>;
+pub type TokenImageIdsMap = StableBTreeMap<String, TokenImageIdWrapper, Memory>;
 
 const CANISTER_IDS_MEMORY: MemoryId = MemoryId::new(0);
 const INDEX_CANISTER_IDS_MEMORY: MemoryId = MemoryId::new(1);
-const IMAGE_IDS_MEMORY: MemoryId = MemoryId::new(2);
+const PROFILE_IMAGE_IDS_MEMORY: MemoryId = MemoryId::new(2);
 const SALE_DETAILS_MEMORY: MemoryId = MemoryId::new(3);
 const USER_ACCOUNTS_MEMORY: MemoryId = MemoryId::new(4);
 const COVER_IMAGE_IDS_MEMORY: MemoryId = MemoryId::new(5);
 const FUNDS_RAISED_MEMORY: MemoryId = MemoryId::new(6);
 const CONTRIBUTIONS_MEMORY: MemoryId = MemoryId::new(7);
 const IMPORTED_CANISTER_IDS_MEMORY: MemoryId = MemoryId::new(8);
+const TOKEN_IMAGE_IDS_MEMORY: MemoryId = MemoryId::new(9);
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
@@ -42,13 +44,14 @@ thread_local! {
         MEMORY_MANAGER.with(|mm| State {
             canister_ids: CanisterIdsMap::init(mm.borrow().get(CANISTER_IDS_MEMORY)),
             index_canister_ids: IndexCanisterIdsMap::init(mm.borrow().get(INDEX_CANISTER_IDS_MEMORY)),
-            image_ids: ImageIdsMap::init(mm.borrow().get(IMAGE_IDS_MEMORY)),
+            profile_image_ids: ProfileImageIdsMap::init(mm.borrow().get(PROFILE_IMAGE_IDS_MEMORY)),
             sale_details: SaleDetailsMap::init(mm.borrow().get(SALE_DETAILS_MEMORY)),
             user_accounts: UserAccountsMap::init(mm.borrow().get(USER_ACCOUNTS_MEMORY)),
             cover_image_ids: CoverImageIdsMap::init(mm.borrow().get(COVER_IMAGE_IDS_MEMORY)),
             funds_raised: FundsRaisedMap::init(mm.borrow().get(FUNDS_RAISED_MEMORY)),
             contributions: ContributionsMap::init(mm.borrow().get(CONTRIBUTIONS_MEMORY)),
             imported_canister_ids: ImportedCanisterIdsMap::init(mm.borrow().get(IMPORTED_CANISTER_IDS_MEMORY)),
+            token_image_ids: TokenImageIdsMap::init(mm.borrow().get(TOKEN_IMAGE_IDS_MEMORY)),
         })
     );
 }
@@ -69,8 +72,8 @@ pub fn get_index_canister_ids_memory() -> Memory {
     MEMORY_MANAGER.with(|m| m.borrow().get(INDEX_CANISTER_IDS_MEMORY))
 }
 
-pub fn get_image_ids_memory() -> Memory {
-    MEMORY_MANAGER.with(|m| m.borrow().get(IMAGE_IDS_MEMORY))
+pub fn get_profile_image_ids_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(PROFILE_IMAGE_IDS_MEMORY))
 }
 
 pub fn get_sale_details_memory() -> Memory {
@@ -97,6 +100,10 @@ pub fn get_imported_canister_ids_memory() -> Memory {
     MEMORY_MANAGER.with(|m| m.borrow().get(IMPORTED_CANISTER_IDS_MEMORY))
 }
 
+pub fn get_token_image_ids_memory() -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(TOKEN_IMAGE_IDS_MEMORY))
+}
+
 #[init]
 fn init() {
     STATE.with(|state| {
@@ -113,13 +120,14 @@ impl State {
         Self {
             canister_ids: init_canister_ids(),
             index_canister_ids: init_index_canister_ids(),
-            image_ids: init_image_ids(),
+            profile_image_ids: init_profile_image_ids(),
             sale_details: init_sale_details(),
             user_accounts: init_user_accounts(),
             cover_image_ids: init_cover_image_ids(),
             funds_raised: init_funds_raised_map(),
             contributions: init_contributions(),
             imported_canister_ids: init_imported_canister_ids(),
+            token_image_ids:init_token_image_ids(),
         }
     }
 }
@@ -140,8 +148,8 @@ pub fn init_index_canister_ids() -> IndexCanisterIdsMap {
 }
 
 
-pub fn init_image_ids() -> ImageIdsMap {
-    ImageIdsMap::init(get_image_ids_memory())
+pub fn init_profile_image_ids() -> ProfileImageIdsMap {
+    ProfileImageIdsMap::init(get_profile_image_ids_memory())
 }
 
 pub fn init_sale_details() -> SaleDetailsMap {
@@ -168,6 +176,9 @@ pub fn init_imported_canister_ids() -> ImportedCanisterIdsMap {
     ImportedCanisterIdsMap::init(get_imported_canister_ids_memory())
 }
 
+pub fn init_token_image_ids() -> TokenImageIdsMap {
+    TokenImageIdsMap::init(get_token_image_ids_memory())
+}
 
 impl Storable for U64Wrapper {
     fn to_bytes(&self) -> Cow<[u8]> {
@@ -205,7 +216,7 @@ impl Storable for IndexCanisterIdWrapper {
     const BOUND: Bound = Bound::Unbounded;
 }
 
-impl Storable for ImageIdWrapper {
+impl Storable for ProfileImageIdWrapper {
     fn to_bytes(&self) -> Cow<[u8]> {
         Cow::Owned(Encode!(self).unwrap())
     }
@@ -254,6 +265,18 @@ impl Storable for CoverImageIdWrapper {
 }
 
 impl Storable for ImportedCanisterIdWrapper {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(Encode!(self).unwrap())
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(bytes.as_ref(), Self).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
+impl Storable for TokenImageIdWrapper {
     fn to_bytes(&self) -> Cow<[u8]> {
         Cow::Owned(Encode!(self).unwrap())
     }

--- a/src/icplaunchpad_backend/src/types.rs
+++ b/src/icplaunchpad_backend/src/types.rs
@@ -8,10 +8,11 @@ use crate::state_handler::*;
 pub struct State {
     pub canister_ids: CanisterIdsMap,
     pub index_canister_ids: IndexCanisterIdsMap,
-    pub image_ids: ImageIdsMap,
+    pub profile_image_ids: ProfileImageIdsMap,
     pub sale_details: SaleDetailsMap,
     pub user_accounts: UserAccountsMap,
     pub cover_image_ids: CoverImageIdsMap,
+    pub token_image_ids: TokenImageIdsMap,
     pub funds_raised: FundsRaisedMap,
     pub contributions: ContributionsMap,
     pub imported_canister_ids: ImportedCanisterIdsMap,
@@ -364,6 +365,16 @@ pub struct UserAccountWrapper {
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct CoverImageIdWrapper {
+    pub image_id: u32,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct ProfileImageIdWrapper {
+    pub image_id: u32,
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub struct TokenImageIdWrapper {
     pub image_id: u32,
 }
 


### PR DESCRIPTION
- new map added to resolve conflicts of duplicate ledger ids.
- three different maps for profile, cover, token images respectively.
- Logic changed according to the changes in update and query files.